### PR TITLE
feat: enable config file upload and wire up start evolution API

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -41,6 +41,8 @@ export default function ProjectHubPage(){
     { id: 'accuracy', label: 'accuracy', weight: 0.5 },
   ]);
   const [cfg, setCfg] = useState<RunConfig>({ generations: 10, population: 24, mutation: 0.15, seed: 42, model: 'gpt-5' });
+  const [cfgFile, setCfgFile] = useState<File | null>(null);
+  const [cfgFileName, setCfgFileName] = useState<string>('');
   const [isStarting, setIsStarting] = useState<boolean>(false);
 
   const usedSeed = useMemo(()=> chooseSeed(seedCode, code), [seedCode, code]);
@@ -54,11 +56,12 @@ export default function ProjectHubPage(){
   const handleStartEvolution = async () => {
     setIsStarting(true);
     try {
-      const result = await startEvolution({ 
-        code: usedSeed, 
-        evaluator: evaluatorText, 
-        metrics, 
-        config: cfg 
+      const result = await startEvolution({
+        code: usedSeed,
+        evaluator: evaluatorText,
+        metrics,
+        config: cfg,
+        configFile: cfgFile || undefined,
       });
       
       // Save runId to localStorage
@@ -183,11 +186,33 @@ export default function ProjectHubPage(){
 
               <div className="rounded-2xl border border-slate-200 bg-white p-4">
                 <div className="mb-3 text-sm font-medium text-slate-900">Run Configuration</div>
+                <div className="mb-2 flex items-center gap-2 text-xs text-slate-500">
+                  <label className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-slate-100">
+                    <span>Upload</span>
+                    <input
+                      data-testid="upload-config"
+                      type="file"
+                      className="hidden"
+                      accept=".json,.yaml,.yml"
+                      onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setCfgFile(f); setCfgFileName(f.name); }}
+                    />
+                  </label>
+                  {cfgFileName && (
+                    <button
+                      data-testid="clear-config"
+                      className="rounded-md px-2 py-1 hover:bg-slate-100"
+                      onClick={()=>{ setCfgFile(null); setCfgFileName(''); }}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                {cfgFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {cfgFileName}</div>}
                 <div className="grid grid-cols-2 gap-3">
                   {['generations','population','mutation','seed'].map((k)=> (
                     <label key={k} className="flex flex-col gap-1 text-sm">
                       <span className="text-xs text-slate-500">{k}</span>
-                      <input data-testid={`cfg-${k}`} type="number" step={k==='mutation'?0.01:1}
+                      <input data-testid={`cfg-${k}`} type="number" step={k==='mutation'?0.01:1} 
                         value={(cfg as any)[k]} onChange={(e)=> setCfg({ ...cfg, [k]: Number(e.target.value) })}
                         className="rounded-lg border border-slate-200 bg-white px-3 py-2 outline-none focus:border-violet-300 focus:ring-2 focus:ring-violet-200"/>
                     </label>

--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef, useState } from 'react';
 import MonacoEditor from '@/components/MonacoEditor';
 import { useStarted } from '@/lib/state';
 import { startEvolution } from '@/lib/api';
-import type { Metric, RunConfig } from '@/lib/world';
+import type { Metric } from '@/lib/world';
 import LineChart from '@/components/LineChart';
 import { useRouter } from 'next/navigation';
 
@@ -40,7 +40,6 @@ export default function ProjectHubPage(){
     { id: 'latency', label: 'latency', weight: 0.5 },
     { id: 'accuracy', label: 'accuracy', weight: 0.5 },
   ]);
-  const [cfg, setCfg] = useState<RunConfig>({ generations: 10, population: 24, mutation: 0.15, seed: 42, model: 'gpt-5' });
   const [cfgFile, setCfgFile] = useState<File | null>(null);
   const [cfgFileName, setCfgFileName] = useState<string>('');
   const [isStarting, setIsStarting] = useState<boolean>(false);
@@ -60,7 +59,6 @@ export default function ProjectHubPage(){
         code: usedSeed,
         evaluator: evaluatorText,
         metrics,
-        config: cfg,
         configFile: cfgFile || undefined,
       });
       
@@ -90,7 +88,7 @@ export default function ProjectHubPage(){
               <p className="mt-3 text-slate-600">AlphaEvolve 将遗传算法与多指标评估结合，自动产生候选实现、并在多个岛屿并行演化。实时监控整体性能曲线，比较不同变体，快速找到更优解。</p>
               <ul className="mt-5 space-y-2 text-sm text-slate-600 list-disc list-inside">
                 <li>支持自定义 <span className="font-medium">Seed Algorithm</span> 与 <span className="font-medium">Evaluator</span></li>
-                <li>多指标优化（Latency/Accuracy/…）与模型选择</li>
+                <li>多指标优化（Latency/Accuracy/…）</li>
                 <li>监控面板与结果工作台，便于对比与回溯</li>
               </ul>
               <div className="mt-6 flex items-center gap-3">
@@ -186,7 +184,7 @@ export default function ProjectHubPage(){
 
               <div className="rounded-2xl border border-slate-200 bg-white p-4">
                 <div className="mb-3 text-sm font-medium text-slate-900">Run Configuration</div>
-                <div className="mb-2 flex items-center gap-2 text-xs text-slate-500">
+                <div className="flex items-center gap-2 text-xs text-slate-500">
                   <label className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-slate-100">
                     <span>Upload</span>
                     <input
@@ -207,28 +205,13 @@ export default function ProjectHubPage(){
                     </button>
                   )}
                 </div>
-                {cfgFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {cfgFileName}</div>}
-                <div className="grid grid-cols-2 gap-3">
-                  {['generations','population','mutation','seed'].map((k)=> (
-                    <label key={k} className="flex flex-col gap-1 text-sm">
-                      <span className="text-xs text-slate-500">{k}</span>
-                      <input data-testid={`cfg-${k}`} type="number" step={k==='mutation'?0.01:1} 
-                        value={(cfg as any)[k]} onChange={(e)=> setCfg({ ...cfg, [k]: Number(e.target.value) })}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-2 outline-none focus:border-violet-300 focus:ring-2 focus:ring-violet-200"/>
-                    </label>
-                  ))}
-                  <label className="col-span-2 flex flex-col gap-1 text-sm">
-                    <span className="text-xs text-slate-500">model</span>
-                    <select data-testid="cfg-model" value={cfg.model} onChange={(e)=> setCfg({ ...cfg, model: e.target.value })}
-                      className="rounded-lg border border-slate-200 bg-white px-3 py-2 outline-none focus:border-violet-300 focus:ring-2 focus:ring-violet-200">
-                      <option value="gpt-5">GPT-5</option>
-<option value="o3">OpenAI o3</option>
-                      <option value="gpt-4o">GPT-4o</option>
-                      <option value="qwen2.5-coder-32b">Qwen2.5-Coder-32B</option>
-                      <option value="deepseek-coder-v2">DeepSeek-Coder-V2</option>
-                    </select>
-                  </label>
-                </div>
+                {cfgFileName ? (
+                  <div className="mt-2 truncate text-xs text-slate-500">Uploaded: {cfgFileName}</div>
+                ) : (
+                  <div className="mt-2 rounded-lg border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+                    Upload a config file (.json/.yaml)
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/alpha_frontend/lib/api.ts
+++ b/alpha_frontend/lib/api.ts
@@ -1,8 +1,8 @@
-import type { Metric, RunConfig } from './world';
+import type { Metric } from './world';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 
-export async function startEvolution(payload: { code: string; evaluator?: string; metrics: Metric[]; config: RunConfig; configFile?: File }){
+export async function startEvolution(payload: { code: string; evaluator?: string; metrics: Metric[]; configFile?: File }){
   if (!payload?.code) throw new Error('startEvolution: code required');
   if (!Array.isArray(payload?.metrics)) throw new Error('startEvolution: metrics must be array');
 
@@ -10,7 +10,6 @@ export async function startEvolution(payload: { code: string; evaluator?: string
   formData.append('code', payload.code);
   if (payload.evaluator) formData.append('evaluator', payload.evaluator);
   formData.append('metrics', JSON.stringify(payload.metrics));
-  formData.append('config', JSON.stringify(payload.config));
   if (payload.configFile) formData.append('config_file', payload.configFile);
 
   const response = await fetch(`${API_BASE}/start-evolution`, {

--- a/alpha_frontend/lib/api.ts
+++ b/alpha_frontend/lib/api.ts
@@ -1,9 +1,26 @@
 import type { Metric, RunConfig } from './world';
 
-export async function startEvolution(payload: { code: string; evaluator?: string; metrics: Metric[]; config: RunConfig }){
-  await new Promise((r)=>setTimeout(r, 80));
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function startEvolution(payload: { code: string; evaluator?: string; metrics: Metric[]; config: RunConfig; configFile?: File }){
   if (!payload?.code) throw new Error('startEvolution: code required');
   if (!Array.isArray(payload?.metrics)) throw new Error('startEvolution: metrics must be array');
-  console.log('startEvolution:success', { runId: `run_${Date.now()}` });
-  return { ok: true as const, runId: `run_${Date.now()}` };
+
+  const formData = new FormData();
+  formData.append('code', payload.code);
+  if (payload.evaluator) formData.append('evaluator', payload.evaluator);
+  formData.append('metrics', JSON.stringify(payload.metrics));
+  formData.append('config', JSON.stringify(payload.config));
+  if (payload.configFile) formData.append('config_file', payload.configFile);
+
+  const response = await fetch(`${API_BASE}/start-evolution`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`startEvolution failed: ${response.status}`);
+  }
+
+  return response.json();
 }

--- a/alpha_frontend/lib/world.ts
+++ b/alpha_frontend/lib/world.ts
@@ -1,5 +1,4 @@
 export interface Metric { id: string; label: string; weight: number }
-export interface RunConfig { generations: number; population: number; mutation: number; seed: number; model: string }
 export interface CodeScore { code: string; score: number }
 export interface GenerationSnapshot { codes: CodeScore[] }
 export interface IslandData { id: string; gens: GenerationSnapshot[] }

--- a/openevolve/api.py
+++ b/openevolve/api.py
@@ -49,12 +49,31 @@ def health():
 def start_evolution():
     """Start a new evolution process"""
     try:
-        data = request.get_json()
-        if not data:
-            return jsonify({'error': 'No JSON data provided'}), 400
-        
+        # Support both JSON and multipart form data
+        if request.files:
+            form = request.form
+            code = form.get('code', '')
+            evaluator = form.get('evaluator', '')
+            metrics = json.loads(form.get('metrics', '[]'))
+            config_dict = json.loads(form.get('config', '{}'))
+            config_file_obj = request.files.get('config_file')
+        else:
+            data = request.get_json()
+            if not data:
+                return jsonify({'error': 'No data provided'}), 400
+            code = data.get('code', '')
+            evaluator = data.get('evaluator', '')
+            metrics = data.get('metrics', [])
+            config_dict = data.get('config', {})
+            config_file_obj = None
+
         # Create evolution request
-        evolution_request = EvolutionRequest(data)
+        evolution_request = EvolutionRequest({
+            'code': code,
+            'evaluator': evaluator,
+            'metrics': metrics,
+            'config': config_dict,
+        })
         
         # Create temporary files for code and evaluator
         temp_dir = Path(f'/tmp/openevolve_{evolution_request.run_id}')
@@ -69,30 +88,38 @@ def start_evolution():
         evaluator_file = temp_dir / 'evaluator.py'
         with open(evaluator_file, 'w') as f:
             f.write(evolution_request.evaluator)
-        
-        # Create config
-        config_dict = evolution_request.config
-        config = Config()
-        
-        # Map frontend config to backend config
-        if 'generations' in config_dict:
-            config.max_iterations = config_dict['generations']
-        if 'population' in config_dict:
-            config.database.population_size = config_dict['population']
-        if 'mutation' in config_dict:
-            # Mutation rate is not directly mapped in current config
-            pass
-        if 'seed' in config_dict:
-            config.random_seed = config_dict['seed']
-        if 'model' in config_dict:
-            # Update model in LLM config
-            if config.llm.models:
-                config.llm.models[0].name = config_dict['model']
-        
+
+        # Handle configuration
+        config_path = None
+        if config_file_obj:
+            config_filename = config_file_obj.filename or 'config.yaml'
+            config_file_path = temp_dir / config_filename
+            config_file_obj.save(config_file_path)
+            config_path = str(config_file_path)
+
+        config = None
+        if config_path is None:
+            config = Config()
+            # Map frontend config to backend config
+            if 'generations' in config_dict:
+                config.max_iterations = config_dict['generations']
+            if 'population' in config_dict:
+                config.database.population_size = config_dict['population']
+            if 'mutation' in config_dict:
+                # Mutation rate is not directly mapped in current config
+                pass
+            if 'seed' in config_dict:
+                config.random_seed = config_dict['seed']
+            if 'model' in config_dict:
+                # Update model in LLM config
+                if config.llm.models:
+                    config.llm.models[0].name = config_dict['model']
+
         # Initialize OpenEvolve
         openevolve = OpenEvolve(
             initial_program_path=str(seed_file),
             evaluation_file=str(evaluator_file),
+            config_path=config_path,
             config=config,
             output_dir=str(temp_dir / 'output')
         )


### PR DESCRIPTION
## Summary
- Allow uploading optional config file via frontend and pass to backend
- Handle JSON or multipart form data in `/start-evolution` API and pass config path to OpenEvolve
- Call backend API from frontend instead of stub

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'openevolve', ImportError: libmlx.so: cannot open shared object file)*
- `npm test` in alpha_frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb638cf7083289d776b22e8b330cb