### PR TITLE
Handle missing JSON Content-Type in start-evolution endpoint

### DIFF
--- a/openevolve/api.py
+++ b/openevolve/api.py
@@ -48,9 +48,9 @@ def start_evolution():
             metrics = json.loads(form.get('metrics', '[]'))
             config_file_obj = request.files.get('config_file')
         else:
-            data = request.get_json()
+            data = request.get_json(silent=True)
             if not data:
-                return jsonify({'error': 'No data provided'}), 400
+                return jsonify({'error': "Invalid or missing JSON. Set Content-Type to 'application/json'."}), 415
             code = data.get('code', '')
             evaluator = data.get('evaluator', '')
             metrics = data.get('metrics', [])


### PR DESCRIPTION
## Summary
- Handle requests missing application/json by using `request.get_json(silent=True)`
- Return a 415 error with a clear message when JSON is absent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openevolve')*

------
https://chatgpt.com/codex/tasks/task_e_68adba02db188328b55b459440354925