### PR TITLE
Restrict start-evolution endpoint to multipart form data

### DIFF
--- a/openevolve/api.py
+++ b/openevolve/api.py
@@ -24,63 +24,69 @@ CORS(app)  # Enable CORS for all routes
 evolutions: Dict[str, OpenEvolve] = {}
 evolution_tasks: Dict[str, asyncio.Task] = {}
 
+
 class EvolutionRequest:
     def __init__(self, data: Dict[str, Any]):
-        self.code = data.get('code', '')
-        self.evaluator = data.get('evaluator', '')
-        self.metrics = data.get('metrics', [])
+        self.code = data.get("code", "")
+        self.evaluator = data.get("evaluator", "")
+        self.metrics = data.get("metrics", [])
         self.run_id = str(uuid.uuid4())
 
-@app.route('/health', methods=['GET'])
+
+@app.route("/health", methods=["GET"])
 def health():
     """Health check endpoint"""
-    return jsonify({'status': 'healthy'}), 200
+    return jsonify({"status": "healthy"}), 200
 
-@app.route('/start-evolution', methods=['POST'])
+
+@app.route("/start-evolution", methods=["POST"])
 def start_evolution():
     """Start a new evolution process"""
     try:
-        # Support both JSON and multipart form data
-        if request.files:
-            form = request.form
-            code = form.get('code', '')
-            evaluator = form.get('evaluator', '')
-            metrics = json.loads(form.get('metrics', '[]'))
-            config_file_obj = request.files.get('config_file')
-        else:
-            data = request.get_json(silent=True)
-            if not data:
-                return jsonify({'error': "Invalid or missing JSON. Set Content-Type to 'application/json'."}), 415
-            code = data.get('code', '')
-            evaluator = data.get('evaluator', '')
-            metrics = data.get('metrics', [])
-            config_file_obj = None
+        # Frontend submits multipart/form-data using FormData
+        if request.mimetype != "multipart/form-data":
+            return (
+                jsonify({"error": "Unsupported media type. Use multipart/form-data."}),
+                415,
+            )
+
+        form = request.form
+        code = form.get("code", "")
+        evaluator = form.get("evaluator", "")
+        metrics_raw = form.get("metrics", "[]")
+        try:
+            metrics = json.loads(metrics_raw)
+        except json.JSONDecodeError:
+            return jsonify({"error": "Invalid metrics format; expected JSON array."}), 400
+        config_file_obj = request.files.get("config_file")
 
         # Create evolution request
-        evolution_request = EvolutionRequest({
-            'code': code,
-            'evaluator': evaluator,
-            'metrics': metrics,
-        })
-        
+        evolution_request = EvolutionRequest(
+            {
+                "code": code,
+                "evaluator": evaluator,
+                "metrics": metrics,
+            }
+        )
+
         # Create temporary files for code and evaluator
-        temp_dir = Path(f'/tmp/openevolve_{evolution_request.run_id}')
+        temp_dir = Path(f"/tmp/openevolve_{evolution_request.run_id}")
         temp_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Save seed code
-        seed_file = temp_dir / 'seed.py'
-        with open(seed_file, 'w') as f:
+        seed_file = temp_dir / "seed.py"
+        with open(seed_file, "w") as f:
             f.write(evolution_request.code)
-        
+
         # Save evaluator
-        evaluator_file = temp_dir / 'evaluator.py'
-        with open(evaluator_file, 'w') as f:
+        evaluator_file = temp_dir / "evaluator.py"
+        with open(evaluator_file, "w") as f:
             f.write(evolution_request.evaluator)
 
         # Handle configuration
         config_path = None
         if config_file_obj:
-            config_filename = config_file_obj.filename or 'config.yaml'
+            config_filename = config_file_obj.filename or "config.yaml"
             config_file_path = temp_dir / config_filename
             config_file_obj.save(config_file_path)
             config_path = str(config_file_path)
@@ -90,12 +96,12 @@ def start_evolution():
             initial_program_path=str(seed_file),
             evaluation_file=str(evaluator_file),
             config_path=config_path,
-            output_dir=str(temp_dir / 'output')
+            output_dir=str(temp_dir / "output"),
         )
-        
+
         # Store evolution
         evolutions[evolution_request.run_id] = openevolve
-        
+
         # Run evolution in background
         def run_evolution():
             try:
@@ -109,49 +115,44 @@ def start_evolution():
                 # Clean up
                 if evolution_request.run_id in evolutions:
                     del evolutions[evolution_request.run_id]
-        
+
         # Start evolution in background thread
         import threading
+
         thread = threading.Thread(target=run_evolution)
         thread.daemon = True
         thread.start()
-        
-        return jsonify({
-            'status': 'started',
-            'runId': evolution_request.run_id
-        }), 200
-        
+
+        return jsonify({"status": "started", "runId": evolution_request.run_id}), 200
+
     except Exception as e:
         logger.error(f"Error starting evolution: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
 
-@app.route('/evolution-status/<run_id>', methods=['GET'])
+
+@app.route("/evolution-status/<run_id>", methods=["GET"])
 def evolution_status(run_id: str):
     """Get the status of an evolution process"""
     if run_id not in evolutions:
-        return jsonify({'error': 'Evolution not found'}), 404
-    
+        return jsonify({"error": "Evolution not found"}), 404
+
     # For now, just return that it's running
     # In a more complete implementation, we would track progress
-    return jsonify({
-        'status': 'running',
-        'runId': run_id
-    }), 200
+    return jsonify({"status": "running", "runId": run_id}), 200
 
-@app.route('/stop-evolution/<run_id>', methods=['POST'])
+
+@app.route("/stop-evolution/<run_id>", methods=["POST"])
 def stop_evolution(run_id: str):
     """Stop an evolution process"""
     if run_id not in evolutions:
-        return jsonify({'error': 'Evolution not found'}), 404
-    
+        return jsonify({"error": "Evolution not found"}), 404
+
     # In a more complete implementation, we would signal the evolution to stop
     # For now, we'll just remove it from tracking
     del evolutions[run_id]
-    
-    return jsonify({
-        'status': 'stopped',
-        'runId': run_id
-    }), 200
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8000, debug=False)
+    return jsonify({"status": "stopped", "runId": run_id}), 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=False)


### PR DESCRIPTION
## Summary
- Handle multipart/form-data submissions for `/start-evolution`
- Return 415 when content-type is not multipart and validate metrics

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'openevolve'; ImportError: libmlx.so missing)*
- `pip install -e .` *(fails: Could not find a version that satisfies setuptools>=42 due to proxy issues)*

------
https://chatgpt.com/codex/tasks/task_e_68adbf1d1ba48328825584ca8de44415