### PR TITLE
Fix navigation after starting evolution

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -61,12 +61,16 @@ export default function ProjectHubPage(){
         metrics,
         configFile: cfgFile || undefined,
       });
-      
+
       // Save runId to localStorage
-      if (result.ok && result.runId) {
+      if (result.runId) {
         localStorage.setItem('currentRunId', result.runId);
-        // Navigate to monitor page with runId
-        router.push(`/monitor?runId=${result.runId}`);
+        if (result.path) {
+          localStorage.setItem('currentOutputPath', result.path);
+        }
+        // Navigate to monitor page with runId and path
+        const pathParam = result.path ? `&path=${encodeURIComponent(result.path)}` : '';
+        router.push(`/monitor?runId=${result.runId}${pathParam}`);
       }
     } catch (error) {
       console.error('Failed to start evolution:', error);

--- a/openevolve/api.py
+++ b/openevolve/api.py
@@ -104,11 +104,12 @@ def start_evolution():
             config_path = str(config_file_path)
 
         # Initialize OpenEvolve
+        output_path = str(temp_dir / "output")
         openevolve = OpenEvolve(
             initial_program_path=str(seed_file),
             evaluation_file=str(evaluator_file),
             config_path=config_path,
-            output_dir=str(temp_dir / "output"),
+            output_dir=output_path,
         )
 
         # Store evolution
@@ -135,7 +136,16 @@ def start_evolution():
         thread.daemon = True
         thread.start()
 
-        return jsonify({"status": "started", "runId": evolution_request.run_id}), 200
+        return (
+            jsonify(
+                {
+                    "status": "started",
+                    "runId": evolution_request.run_id,
+                    "path": output_path,
+                }
+            ),
+            200,
+        )
 
     except Exception as e:
         logger.error(f"Error starting evolution: {e}")

--- a/scripts/static/js/main.js
+++ b/scripts/static/js/main.js
@@ -119,7 +119,10 @@ if (window.STATIC_DATA) {
     loadAndRenderData(window.STATIC_DATA);
 } else {
     function fetchAndRender() {
-        fetch('/api/data')
+        const params = new URLSearchParams(window.location.search);
+        const path = params.get('path');
+        const url = path ? `/api/data?path=${encodeURIComponent(path)}` : '/api/data';
+        fetch(url)
             .then(resp => resp.json())
             .then(data => {
                 const dataStr = JSON.stringify(data);

--- a/scripts/visualizer.py
+++ b/scripts/visualizer.py
@@ -4,7 +4,7 @@ import glob
 import logging
 import shutil
 import re as _re
-from flask import Flask, render_template, render_template_string, jsonify
+from flask import Flask, render_template, render_template_string, jsonify, request
 
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ checkpoint_dir = None  # Global variable to store the checkpoint directory
 @app.route("/api/data")
 def data():
     global checkpoint_dir
-    base_folder = os.environ.get("EVOLVE_OUTPUT", "examples/")
+    base_folder = request.args.get("path") or os.environ.get("EVOLVE_OUTPUT", "examples/")
     checkpoint_dir = find_latest_checkpoint(base_folder)
     if not checkpoint_dir:
         logger.info(f"No checkpoints found in {base_folder}")


### PR DESCRIPTION
## Summary
- ensure project hub stores run info and navigates to monitor without relying on a non-existent `ok` flag

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae5d4425908328a2aa4cf3ba627e88