### PR TITLE
Run evolutions in separate process

### DIFF
--- a/openevolve/api.py
+++ b/openevolve/api.py
@@ -6,6 +6,7 @@ import json
 import uuid
 import asyncio
 import logging
+import multiprocessing
 from pathlib import Path
 from typing import Dict, Any
 from flask import Flask, request, jsonify
@@ -21,8 +22,7 @@ app = Flask(__name__)
 CORS(app)  # Enable CORS for all routes
 
 # Store for running evolutions
-evolutions: Dict[str, OpenEvolve] = {}
-evolution_tasks: Dict[str, asyncio.Task] = {}
+evolutions: Dict[str, multiprocessing.Process] = {}
 
 
 class EvolutionRequest:
@@ -31,6 +31,22 @@ class EvolutionRequest:
         self.evaluator = data.get("evaluator", "")
         self.metrics = data.get("metrics", [])
         self.run_id = str(uuid.uuid4())
+
+
+def run_evolution_process(
+    seed_file: str, evaluator_file: str, config_path: str, output_path: str, run_id: str
+):
+    """Run OpenEvolve in a separate process"""
+    try:
+        openevolve = OpenEvolve(
+            initial_program_path=seed_file,
+            evaluation_file=evaluator_file,
+            config_path=config_path,
+            output_dir=output_path,
+        )
+        asyncio.run(openevolve.run())
+    except Exception as e:
+        logger.error(f"Error in evolution {run_id}: {e}")
 
 
 @app.route("/health", methods=["GET"])
@@ -103,38 +119,19 @@ def start_evolution():
                 f.write(config_content)
             config_path = str(config_file_path)
 
-        # Initialize OpenEvolve
+        # Initialize output path
         output_path = str(temp_dir / "output")
-        openevolve = OpenEvolve(
-            initial_program_path=str(seed_file),
-            evaluation_file=str(evaluator_file),
-            config_path=config_path,
-            output_dir=output_path,
+
+        # Start evolution in background process
+        process = multiprocessing.Process(
+            target=run_evolution_process,
+            args=(str(seed_file), str(evaluator_file), config_path, output_path, evolution_request.run_id),
         )
+        process.daemon = True
+        process.start()
 
-        # Store evolution
-        evolutions[evolution_request.run_id] = openevolve
-
-        # Run evolution in background
-        def run_evolution():
-            try:
-                # Create new event loop for this thread
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(openevolve.run())
-            except Exception as e:
-                logger.error(f"Error in evolution {evolution_request.run_id}: {e}")
-            finally:
-                # Clean up
-                if evolution_request.run_id in evolutions:
-                    del evolutions[evolution_request.run_id]
-
-        # Start evolution in background thread
-        import threading
-
-        thread = threading.Thread(target=run_evolution)
-        thread.daemon = True
-        thread.start()
+        # Store process handle
+        evolutions[evolution_request.run_id] = process
 
         return (
             jsonify(
@@ -155,23 +152,29 @@ def start_evolution():
 @app.route("/evolution-status/<run_id>", methods=["GET"])
 def evolution_status(run_id: str):
     """Get the status of an evolution process"""
-    if run_id not in evolutions:
+    process = evolutions.get(run_id)
+    if not process:
         return jsonify({"error": "Evolution not found"}), 404
 
-    # For now, just return that it's running
-    # In a more complete implementation, we would track progress
-    return jsonify({"status": "running", "runId": run_id}), 200
+    status = "running" if process.is_alive() else "completed"
+    if not process.is_alive():
+        evolutions.pop(run_id, None)
+
+    return jsonify({"status": status, "runId": run_id}), 200
 
 
 @app.route("/stop-evolution/<run_id>", methods=["POST"])
 def stop_evolution(run_id: str):
     """Stop an evolution process"""
-    if run_id not in evolutions:
+    process = evolutions.get(run_id)
+    if not process:
         return jsonify({"error": "Evolution not found"}), 404
 
-    # In a more complete implementation, we would signal the evolution to stop
-    # For now, we'll just remove it from tracking
-    del evolutions[run_id]
+    if process.is_alive():
+        process.terminate()
+        process.join()
+
+    evolutions.pop(run_id, None)
 
     return jsonify({"status": "stopped", "runId": run_id}), 200
 


### PR DESCRIPTION
## Summary
- avoid signal errors by running each evolution in its own process rather than a background thread
- track running processes and expose status/stop endpoints accordingly

## Testing
- `pytest` *(fails: ImportError: libmlx.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aea9ece028832899b02cc526edf084