### PR TITLE
Open visualizer after starting evolution

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -68,9 +68,9 @@ export default function ProjectHubPage(){
         if (result.path) {
           localStorage.setItem('currentOutputPath', result.path);
         }
-        // Navigate to monitor page with runId and path
+        // Navigate directly to visualization page with runId and path
         const pathParam = result.path ? `&path=${encodeURIComponent(result.path)}` : '';
-        router.push(`/monitor?runId=${result.runId}${pathParam}`);
+        router.push(`/visualize?runId=${result.runId}${pathParam}`);
       }
     } catch (error) {
       console.error('Failed to start evolution:', error);

--- a/alpha_frontend/app/visualize/page.tsx
+++ b/alpha_frontend/app/visualize/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const VISUALIZER_BASE = process.env.NEXT_PUBLIC_VISUALIZER_BASE || 'http://localhost:8080';
+
+export default function VisualizePage() {
+  const [runId, setRunId] = useState<string | null>(null);
+  const [outputPath, setOutputPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedRunId = localStorage.getItem('currentRunId');
+    const storedPath = localStorage.getItem('currentOutputPath');
+    if (storedRunId) {
+      setRunId(storedRunId);
+    }
+    if (storedPath) {
+      setOutputPath(storedPath);
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlRunId = urlParams.get('runId');
+    const urlPath = urlParams.get('path');
+    if (urlRunId) {
+      setRunId(urlRunId);
+      localStorage.setItem('currentRunId', urlRunId);
+    }
+    if (urlPath) {
+      setOutputPath(urlPath);
+      localStorage.setItem('currentOutputPath', urlPath);
+    }
+  }, []);
+
+  const handleStop = async () => {
+    if (!runId) return;
+    try {
+      const response = await fetch(`${API_BASE}/stop-evolution/${runId}`, {
+        method: 'POST',
+      });
+      if (response.ok) {
+        setRunId(null);
+        setOutputPath(null);
+        localStorage.removeItem('currentRunId');
+        localStorage.removeItem('currentOutputPath');
+      }
+    } catch (error) {
+      console.error('Error stopping evolution:', error);
+    }
+  };
+
+  if (!outputPath) {
+    return (
+      <div className="p-4">No visualization available.</div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-end">
+        {runId && (
+          <button
+            onClick={handleStop}
+            className="rounded-xl bg-red-600 px-3 py-2 text-sm font-medium text-white shadow hover:bg-red-700"
+          >
+            Stop
+          </button>
+        )}
+      </div>
+      <iframe
+        src={`${VISUALIZER_BASE}/?path=${encodeURIComponent(outputPath)}`}
+        className="w-full h-[calc(100vh-5rem)] border-0"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dedicated visualization page that embeds the visualizer and exposes a stop button for the active run.
- Redirect Project Hub's start evolution flow directly to the new visualization page.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aeb06663008328b3f35d76f96a27bb