### PR TITLE
Refine project hub layout and uploads

### DIFF
--- a/alpha_frontend/components/TopNav.tsx
+++ b/alpha_frontend/components/TopNav.tsx
@@ -8,15 +8,15 @@ export default function TopNav(){
   const { started } = useStarted();
   const Item = ({href, label}:{href:string; label:string}) => (
     <Link href={href} className={
-      'px-3 py-1 rounded-lg text-sm ' + (pathname===href? 'bg-violet-600 text-white':'hover:bg-slate-100 text-slate-700')
+      'px-4 py-2 rounded-lg text-base ' + (pathname===href? 'bg-violet-600 text-white':'hover:bg-slate-100 text-slate-700')
     }>
       {label}
     </Link>
   );
   return (
-    <div className="flex items-center justify-between border-b border-slate-200 bg-white px-4 h-12">
-      <div className="font-semibold text-slate-900">AlphaEvolve</div>
-      <div data-testid="nav-tabs" aria-hidden={!started} className="flex items-center gap-2">
+    <div className="flex items-center justify-between border-b border-slate-200 bg-white px-6 h-16">
+      <div className="font-semibold text-slate-900 text-xl">AlphaEvolve</div>
+      <div data-testid="nav-tabs" aria-hidden={!started} className="flex items-center gap-3">
         {started && <Item href="/project-hub" label="Project Hub"/>}
         {started && <Item href="/monitor" label="Monitor"/>}
         {started && <Item href="/compare" label="Compare"/>}

--- a/alpha_frontend/lib/api.ts
+++ b/alpha_frontend/lib/api.ts
@@ -1,14 +1,9 @@
-import type { Metric } from './world';
-
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-
-export async function startEvolution(payload: { code: string; evaluator?: string; metrics: Metric[]; configFile?: File }){
+export async function startEvolution(payload: { code: string; evaluator?: string; configFile?: File }){
   if (!payload?.code) throw new Error('startEvolution: code required');
-  if (!Array.isArray(payload?.metrics)) throw new Error('startEvolution: metrics must be array');
 
   const body: Record<string, unknown> = {
     code: payload.code,
-    metrics: payload.metrics,
   };
   if (payload.evaluator) body.evaluator = payload.evaluator;
   if (payload.configFile) body.config = await payload.configFile.text();


### PR DESCRIPTION
## Summary
- Expand project hub hero to fill full page
- Simplify start evolution API and remove metrics
- Require YAML config and Python evaluator uploads with clickable placeholders
- Enlarge navigation bar
- Provide inline YAML configuration example for reference

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aebc4efa3083288926ec882d65959b