### PR TITLE
Improve top navigation and fix visualizer tab switching

### DIFF
--- a/alpha_frontend/components/TopNav.tsx
+++ b/alpha_frontend/components/TopNav.tsx
@@ -3,25 +3,37 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useStarted } from '@/lib/state';
 
-export default function TopNav(){
+export default function TopNav() {
   const pathname = usePathname();
   const { started } = useStarted();
-  const Item = ({href, label}:{href:string; label:string}) => (
-    <Link href={href} className={
-      'px-4 py-2 rounded-lg text-base ' + (pathname===href? 'bg-violet-600 text-white':'hover:bg-slate-100 text-slate-700')
-    }>
+
+  const Item = ({ href, label }: { href: string; label: string }) => (
+    <Link
+      href={href}
+      className={
+        'px-4 py-2 rounded-lg text-base transition-colors ' +
+        (pathname === href
+          ? 'bg-violet-600 text-white'
+          : 'text-slate-700 hover:bg-slate-100')
+      }
+    >
       {label}
     </Link>
   );
+
   return (
-    <div className="sticky top-0 z-50 flex items-center justify-between border-b border-slate-200 bg-white/80 px-6 h-16 backdrop-blur shadow-sm">
-      <div className="font-semibold text-slate-900 text-xl">AlphaEvolve</div>
-      <div data-testid="nav-tabs" aria-hidden={!started} className="flex items-center gap-3">
-        {started && <Item href="/project-hub" label="Project Hub"/>}
-        {started && <Item href="/monitor" label="Monitor"/>}
-        {started && <Item href="/compare" label="Compare"/>}
-        {started && <Item href="/results" label="Results"/>}
+    <header className="sticky top-0 z-50 w-full border-b border-slate-200 bg-gradient-to-r from-white to-violet-50/40 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-6">
+        <Link href="/" className="font-semibold text-slate-900 text-xl">
+          AlphaEvolve
+        </Link>
+        <nav data-testid="nav-tabs" aria-hidden={!started} className="flex items-center gap-3">
+          {started && <Item href="/project-hub" label="Project Hub" />}
+          {started && <Item href="/monitor" label="Monitor" />}
+          {started && <Item href="/compare" label="Compare" />}
+          {started && <Item href="/results" label="Results" />}
+        </nav>
       </div>
-    </div>
+    </header>
   );
 }

--- a/alpha_frontend/public/visualizer/js/mainUI.js
+++ b/alpha_frontend/public/visualizer/js/mainUI.js
@@ -29,29 +29,34 @@ if (!document.getElementById('custom-dark-toggle')) {
 
 // Tab switching logic
 const tabs = ["branching", "performance", "list"];
-tabs.forEach(tab => {
-    document.getElementById(`tab-${tab}`).addEventListener('click', function() {
-        tabs.forEach(t => {
-            document.getElementById(`tab-${t}`).classList.remove('active');
-            const view = document.getElementById(`view-${t}`);
-            if (view) view.style.display = 'none';
-        });
-        this.classList.add('active');
-        const view = document.getElementById(`view-${tab}`);
-        if (view) view.style.display = 'block';
-        // Synchronize node selection when switching tabs
-        if (tab === 'list' || tab === 'branching') {
-            if (selectedProgramId) {
-                selectProgram(selectedProgramId);
-                showSidebarContent(window._lastSelectedNodeData || null);
+document.addEventListener('DOMContentLoaded', () => {
+    tabs.forEach(tab => {
+        const tabEl = document.getElementById(`tab-${tab}`);
+        if (!tabEl) return;
+        tabEl.addEventListener('click', function () {
+            tabs.forEach(t => {
+                const tabNode = document.getElementById(`tab-${t}`);
+                if (tabNode) tabNode.classList.remove('active');
+                const view = document.getElementById(`view-${t}`);
+                if (view) view.style.display = 'none';
+            });
+            this.classList.add('active');
+            const view = document.getElementById(`view-${tab}`);
+            if (view) view.style.display = 'block';
+            // Synchronize node selection when switching tabs
+            if (tab === 'list' || tab === 'branching') {
+                if (selectedProgramId) {
+                    selectProgram(selectedProgramId);
+                    showSidebarContent(window._lastSelectedNodeData || null);
+                }
             }
-        }
-        // Disable page scroll for graph tabs
-        if (tab === 'branching' || tab === 'performance') {
-            document.body.style.overflow = 'hidden';
-        } else {
-            document.body.style.overflow = '';
-        }
+            // Disable page scroll for graph tabs
+            if (tab === 'branching' || tab === 'performance') {
+                document.body.style.overflow = 'hidden';
+            } else {
+                document.body.style.overflow = '';
+            }
+        });
     });
 });
 


### PR DESCRIPTION
## Summary
- refine top navigation layout with semantic header, gradient background, and home link
- ensure visualizer Branching/List tabs attach listeners after DOM load so they switch views properly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affcc83f1c8328b1b45603a61864e8