### PR TITLE
feat: pass user context to evaluator

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -80,6 +80,7 @@ export default function ProjectHubPage(){
   const [evalFileName, setEvalFileName] = useState<string>('');
   const [cfgFile, setCfgFile] = useState<File | null>(null);
   const [cfgFileName, setCfgFileName] = useState<string>('');
+  const [contextText, setContextText] = useState<string>('');
   const [isStarting, setIsStarting] = useState<boolean>(false);
 
   const usedSeed = useMemo(()=> chooseSeed(seedCode, code), [seedCode, code]);
@@ -98,10 +99,20 @@ export default function ProjectHubPage(){
   const handleStartEvolution = async () => {
     setIsStarting(true);
     try {
+      let context: Record<string, unknown> | undefined;
+      if (contextText) {
+        try {
+          context = JSON.parse(contextText);
+        } catch (err) {
+          alert('Invalid context JSON');
+          return;
+        }
+      }
       const result = await startEvolution({
         code: usedSeed,
         evaluator: evaluatorText,
         configFile: cfgFile || undefined,
+        context,
       });
 
       // Save runId to localStorage
@@ -354,6 +365,16 @@ export default function ProjectHubPage(){
                   <summary className="cursor-pointer">View example config</summary>
                   <pre className="mt-2 max-h-64 overflow-auto rounded-lg bg-slate-50 p-3 text-left font-mono leading-5 text-slate-700">{SAMPLE_CONFIG}</pre>
                 </details>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="text-sm font-medium text-slate-900">Context</div>
+                <textarea
+                  className="mt-2 h-40 w-full rounded-xl border border-slate-200 p-3 font-mono text-sm leading-6 text-slate-900"
+                  placeholder='{"sort": "name"}'
+                  value={contextText}
+                  onChange={(e)=>setContextText(e.target.value)}
+                />
+                <p className="mt-1 text-xs text-slate-500">Optional JSON context passed to evaluator</p>
               </div>
             </div>
           </div>

--- a/alpha_frontend/lib/api.ts
+++ b/alpha_frontend/lib/api.ts
@@ -1,5 +1,5 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-export async function startEvolution(payload: { code: string; evaluator?: string; configFile?: File }){
+export async function startEvolution(payload: { code: string; evaluator?: string; configFile?: File; context?: Record<string, unknown> }){
   if (!payload?.code) throw new Error('startEvolution: code required');
 
   const body: Record<string, unknown> = {
@@ -7,6 +7,7 @@ export async function startEvolution(payload: { code: string; evaluator?: string
   };
   if (payload.evaluator) body.evaluator = payload.evaluator;
   if (payload.configFile) body.config = await payload.configFile.text();
+  if (payload.context) body.context = payload.context;
 
   const response = await fetch(`${API_BASE}/start-evolution`, {
     method: 'POST',

--- a/openevolve/controller.py
+++ b/openevolve/controller.py
@@ -77,6 +77,7 @@ class OpenEvolve:
         config_path: Optional[str] = None,
         config: Optional[Config] = None,
         output_dir: Optional[str] = None,
+        user_context: Optional[Dict[str, Any]] = None,
     ):
         # Load configuration
         if config is not None:
@@ -90,6 +91,7 @@ class OpenEvolve:
         self.output_dir = output_dir or os.path.join(
             os.path.dirname(initial_program_path), "openevolve_output"
         )
+        self.user_context = user_context or {}
         os.makedirs(self.output_dir, exist_ok=True)
 
         # Set up logging
@@ -158,6 +160,7 @@ class OpenEvolve:
             self.evaluator_prompt_sampler,
             database=self.database,
             suffix=Path(self.initial_program_path).suffix,
+            context=self.user_context,
         )
         self.evaluation_file = evaluation_file
 
@@ -276,7 +279,7 @@ class OpenEvolve:
         # Initialize improved parallel processing
         try:
             self.parallel_controller = ProcessParallelController(
-                self.config, self.evaluation_file, self.database
+                self.config, self.evaluation_file, self.database, user_context=self.user_context
             )
 
             # Set up signal handlers for graceful shutdown

--- a/tests/test_evaluator_context.py
+++ b/tests/test_evaluator_context.py
@@ -1,0 +1,35 @@
+import asyncio
+import asyncio
+import os
+import tempfile
+import unittest
+import shutil
+
+from openevolve.config import EvaluatorConfig
+from openevolve.evaluator import Evaluator
+
+
+class TestEvaluatorContext(unittest.TestCase):
+    """Ensure evaluator receives user context"""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.eval_file = tempfile.NamedTemporaryFile(delete=False, suffix=".py", dir=self.temp_dir)
+        self.eval_file.write(b"def evaluate(program_path, context):\n    return {'received': context.get('key')}\n")
+        self.eval_file.flush()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_context_passed(self):
+        async def run_test():
+            config = EvaluatorConfig()
+            evaluator = Evaluator(config, self.eval_file.name, context={'key': 'value'})
+            result = await evaluator.evaluate_program("print('hi')", "test")
+            self.assertEqual(result.get('received'), 'value')
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow API clients to submit arbitrary context data
- propagate user context through controller and parallel workers to `Evaluator`
- extend `Evaluator` to forward optional context into evaluation functions
- add frontend support and test coverage for context handling

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*
- `PYTHONPATH=. pytest tests/test_evaluator_context.py -q`
- `PYTHONPATH=. pytest tests/test_evaluator_timeout.py::TestEvaluatorTimeout::test_fast_evaluation_completes -q`


------
https://chatgpt.com/codex/tasks/task_e_68b502c3ba748328925a621ec453c727