### PR TITLE
feat(frontend): enlarge prompt editor and highlight code

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -434,7 +434,7 @@ export default function ProjectHubPage(){
                     </button>
                   ))}
                 </div>
-                <MonacoEditor height={180} value={promptValue} onChange={setPromptValue} />
+                <MonacoEditor height={300} value={promptValue} onChange={setPromptValue} />
               </div>
               <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="text-sm font-medium text-slate-900">Context</div>

--- a/alpha_frontend/components/MonacoEditor.tsx
+++ b/alpha_frontend/components/MonacoEditor.tsx
@@ -1,12 +1,31 @@
 'use client';
+import { useMemo } from 'react';
+
+const PY_KEYWORDS = /\b(def|return|for|while|if|else|elif|import|from|as|class|try|except|finally|with|lambda|pass|break|continue|True|False|None)\b/g;
+
+function highlight(code: string) {
+  return code
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(PY_KEYWORDS, '<span class="text-purple-600 font-medium">$1</span>');
+}
+
 export default function MonacoEditor({ value, onChange, height=420 }:{ value:string; onChange?:(v:string)=>void; height?:number }){
+  const highlighted = useMemo(() => highlight(value), [value]);
   return (
-    <textarea
-      value={value}
-      onChange={(e)=>onChange?.(e.target.value)}
-      spellCheck={false}
-      style={{height}}
-      className="w-full rounded-xl border border-slate-200 bg-white p-3 font-mono text-sm leading-6 text-slate-900"
-    />
+    <div className="relative w-full" style={{minHeight: height}}>
+      <textarea
+        value={value}
+        onChange={(e)=>onChange?.(e.target.value)}
+        spellCheck={false}
+        className="absolute inset-0 w-full h-full resize-none rounded-xl border border-slate-200 bg-transparent p-3 font-mono text-base leading-6 text-transparent caret-slate-900"
+      />
+      <pre
+        aria-hidden
+        className="pointer-events-none w-full h-full overflow-auto rounded-xl border border-slate-200 bg-white p-3 font-mono text-base leading-6 text-slate-900"
+        dangerouslySetInnerHTML={{ __html: highlighted + '\n' }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- enlarge project hub prompt editor for better readability
- add simple Python syntax highlighting and bigger font in MonacoEditor

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68b7f92a190c8328941264a25520a259