### PR TITLE
Highlight uploaded config and evaluator

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -80,8 +80,10 @@ export default function ProjectHubPage(){
   const [evalFileName, setEvalFileName] = useState<string>('');
   const [cfgFile, setCfgFile] = useState<File | null>(null);
   const [cfgFileName, setCfgFileName] = useState<string>('');
+  const [cfgText, setCfgText] = useState<string>('');
   const [contextText, setContextText] = useState<string>('');
   const [contextError, setContextError] = useState<string | null>(null);
+  const [showContext, setShowContext] = useState<boolean>(false);
   const [isStarting, setIsStarting] = useState<boolean>(false);
   const [systemPrompt, setSystemPrompt] = useState<string>('');
   const [diffUserPrompt, setDiffUserPrompt] = useState<string>('');
@@ -370,11 +372,7 @@ export default function ProjectHubPage(){
                   {evalFileName ? (
                     <>
                       <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {evalFileName}</div>
-                      <textarea
-                        value={evaluatorText}
-                        readOnly
-                        className="h-40 w-full cursor-not-allowed rounded-xl border border-slate-200 bg-white p-3 font-mono text-sm leading-6 text-slate-900 opacity-80"
-                      />
+                      <MonacoEditor value={evaluatorText} height={160} language="python" readOnly />
                     </>
                   ) : (
                     <label className="flex h-40 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
@@ -392,14 +390,17 @@ export default function ProjectHubPage(){
                       <button
                         data-testid="clear-config"
                         className="rounded-md px-2 py-1 hover:bg-slate-100"
-                        onClick={()=>{ setCfgFile(null); setCfgFileName(''); }}
+                        onClick={()=>{ setCfgFile(null); setCfgFileName(''); setCfgText(''); }}
                       >
                         Clear
                       </button>
                     )}
                   </div>
                   {cfgFileName ? (
-                    <div className="text-xs text-slate-500">Uploaded: {cfgFileName}</div>
+                    <>
+                      <div className="text-xs text-slate-500">Uploaded: {cfgFileName}</div>
+                      <MonacoEditor value={cfgText} height={180} language="yaml" readOnly />
+                    </>
                   ) : (
                     <label className="mt-2 flex h-40 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
 
@@ -409,7 +410,7 @@ export default function ProjectHubPage(){
                         type="file"
                         className="hidden"
                         accept=".yaml"
-                        onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setCfgFile(f); setCfgFileName(f.name); }}
+                        onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setCfgFile(f); setCfgFileName(f.name); setCfgText(await readFileAsText(f)); }}
                       />
                     </label>
                   )}
@@ -485,22 +486,48 @@ export default function ProjectHubPage(){
               <MonacoEditor height={420} value={promptValue} onChange={setPromptValue} />
             </div>
             <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-              <div className="text-sm font-medium text-slate-900">Context</div>
-              <MonacoEditor
-                height={200}
-                value={contextText}
-                onChange={(v)=>{
-                  setContextText(v);
-                  if (v) {
-                    try { JSON.parse(v); setContextError(null); }
-                    catch { setContextError('Invalid JSON'); }
-                  } else {
-                    setContextError(null);
-                  }
-                }}
-              />
-              <p className="mt-1 text-xs text-slate-500">Optional JSON context passed to evaluator</p>
-              {contextError && <p className="mt-1 text-xs text-red-600">{contextError}</p>}
+              <div className="mb-3 flex items-center justify-between">
+                <div className="text-sm font-medium text-slate-900">Context</div>
+                {!showContext ? (
+                  <button
+                    className="rounded-md px-2 py-1 text-xs text-slate-500 hover:bg-slate-100"
+                    onClick={() => setShowContext(true)}
+                  >
+                    Add
+                  </button>
+                ) : (
+                  <button
+                    className="rounded-md px-2 py-1 text-xs text-slate-500 hover:bg-slate-100"
+                    onClick={() => {
+                      setShowContext(false);
+                      setContextText('');
+                      setContextError(null);
+                    }}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              {showContext && (
+                <>
+                  <MonacoEditor
+                    height={200}
+                    value={contextText}
+                    language="json"
+                    onChange={(v)=>{
+                      setContextText(v);
+                      if (v) {
+                        try { JSON.parse(v); setContextError(null); }
+                        catch { setContextError('Invalid JSON'); }
+                      } else {
+                        setContextError(null);
+                      }
+                    }}
+                  />
+                  <p className="mt-1 text-xs text-slate-500">Optional JSON context passed to evaluator</p>
+                  {contextError && <p className="mt-1 text-xs text-red-600">{contextError}</p>}
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/alpha_frontend/components/MonacoEditor.tsx
+++ b/alpha_frontend/components/MonacoEditor.tsx
@@ -2,30 +2,70 @@
 import { useMemo } from 'react';
 
 const PY_KEYWORDS = /\b(def|return|for|while|if|else|elif|import|from|as|class|try|except|finally|with|lambda|pass|break|continue|True|False|None)\b/g;
+const YAML_KEY = /^(\s*)([^:\n#]+):/gm;
+const YAML_COMMENT = /(#.*)$/gm;
+const JSON_KEY = /"([^"\\]+)":/g;
 
-function highlight(code: string) {
-  return code
+function highlight(code: string, language: 'python' | 'yaml' | 'json' = 'python') {
+  let escaped = code
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(PY_KEYWORDS, '<span class="text-purple-600 font-medium">$1</span>');
+    .replace(/>/g, '&gt;');
+
+  if (language === 'python') {
+    escaped = escaped.replace(
+      PY_KEYWORDS,
+      '<span class="text-purple-600 font-medium">$1</span>',
+    );
+  } else if (language === 'yaml') {
+    escaped = escaped
+      .replace(
+        YAML_KEY,
+        '$1<span class="text-blue-600 font-medium">$2</span>:',
+      )
+      .replace(YAML_COMMENT, '<span class="text-slate-400">$1</span>');
+  } else if (language === 'json') {
+    escaped = escaped.replace(
+      JSON_KEY,
+      '"<span class="text-blue-600 font-medium">$1</span>":',
+    );
+  }
+
+  return escaped;
 }
 
-export default function MonacoEditor({ value, onChange, height=420 }:{ value:string; onChange?:(v:string)=>void; height?:number }){
-  const highlighted = useMemo(() => highlight(value), [value]);
+export default function MonacoEditor({
+  value,
+  onChange,
+  height = 420,
+  language = 'python',
+  readOnly = false,
+}:{
+  value: string;
+  onChange?: (v: string) => void;
+  height?: number;
+  language?: 'python' | 'yaml' | 'json';
+  readOnly?: boolean;
+}) {
+  const highlighted = useMemo(
+    () => highlight(value, language),
+    [value, language],
+  );
   return (
-    <div className="relative w-full" style={{minHeight: height}}>
+    <div className="relative w-full" style={{ minHeight: height }}>
       <textarea
         value={value}
-        onChange={(e)=>onChange?.(e.target.value)}
+        onChange={readOnly ? undefined : e => onChange?.(e.target.value)}
+        readOnly={readOnly}
         spellCheck={false}
-        className="absolute inset-0 w-full h-full resize-none rounded-xl border border-slate-200 bg-transparent p-3 font-mono text-base leading-6 text-transparent caret-slate-900"
+        className={`absolute inset-0 h-full w-full resize-none rounded-xl border border-slate-200 bg-transparent p-3 font-mono text-base leading-6 text-transparent caret-slate-900 ${readOnly ? 'cursor-not-allowed' : ''}`}
       />
       <pre
         aria-hidden
-        className="pointer-events-none w-full h-full overflow-auto rounded-xl border border-slate-200 bg-white p-3 font-mono text-base leading-6 text-slate-900"
+        className={`pointer-events-none h-full w-full overflow-auto rounded-xl border border-slate-200 bg-white p-3 font-mono text-base leading-6 text-slate-900 ${readOnly ? 'opacity-80' : ''}`}
         dangerouslySetInnerHTML={{ __html: highlighted + '\n' }}
       />
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- show uploaded config file contents with YAML syntax highlighting
- highlight evaluator scripts using a read-only code viewer
- hide JSON context editor until explicitly requested

## Testing
- `npm run lint` (fails: sh: 1: next: not found)
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68b7fff3c2a083288f89f4f02f0361a0