### PR TITLE
feat: add landing page and refine project hub

### DIFF
--- a/alpha_frontend/app/page.tsx
+++ b/alpha_frontend/app/page.tsx
@@ -1,4 +1,160 @@
-import { redirect } from 'next/navigation';
-export default function Page(){
-  redirect('/project-hub');
+'use client';
+
+import { useRouter } from 'next/navigation';
+import LineChart from '@/components/LineChart';
+import { useStarted } from '@/lib/state';
+
+export default function HomePage() {
+  const router = useRouter();
+  const { setStarted } = useStarted();
+
+  const handleStart = () => {
+    setStarted(true);
+    router.push('/project-hub');
+  };
+
+  return (
+    <main>
+      {/* Hero Section */}
+      <section className="relative overflow-hidden bg-gradient-to-b from-white to-violet-50">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-4 py-24">
+          <div className="grid items-center gap-8 md:grid-cols-2">
+            <div>
+              <span className="inline-flex items-center gap-2 rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-xs font-medium text-violet-700">
+                AlphaEvolve · Evolutionary Coding
+              </span>
+              <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-900">
+                Let your code evolve on its own
+              </h1>
+              <p className="mt-4 text-slate-600">
+                AlphaEvolve combines genetic search and multi-metric evaluation to automatically generate improved implementations.
+                Monitor progress and compare variants in real time.
+              </p>
+              <ul className="mt-6 list-inside list-disc space-y-2 text-sm text-slate-600">
+                <li>
+                  Bring your own <span className="font-medium">seed algorithm</span> and <span className="font-medium">evaluator</span>
+                </li>
+                <li>Optimize for latency, accuracy or any custom metric</li>
+                <li>Track performance history and revisit past runs</li>
+              </ul>
+              <div className="mt-8 flex items-center gap-3">
+                <button
+                  data-testid="landing-start"
+                  onClick={handleStart}
+                  className="rounded-xl bg-violet-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-violet-700"
+                >
+                  Start
+                </button>
+                <span className="text-sm text-slate-500">Jump into the project hub</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="text-sm font-medium text-slate-900">Evolution progress</div>
+              <div className="mt-2 text-xs text-slate-500">Demo data</div>
+              <div className="mt-3">
+                <LineChart
+                  data={[0.1, 0.12, 0.2, 0.18, 0.28, 0.33, 0.38, 0.42, 0.5, 0.58, 0.63, 0.71, 0.76, 0.8, 0.83, 0.86, 0.9, 0.93, 0.95, 0.98]}
+                  height={180}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Features Section */}
+      <section className="bg-slate-50 px-4 py-16">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold text-slate-900">Key features</h2>
+          <div className="mt-8 grid gap-6 md:grid-cols-3">
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-2xl">🤖</div>
+              <h3 className="mt-2 text-lg font-semibold text-slate-900">Automated evolution</h3>
+              <p className="mt-2 text-sm text-slate-600">
+                Generate and refine code implementations with minimal manual work.
+              </p>
+            </div>
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-2xl">🧪</div>
+              <h3 className="mt-2 text-lg font-semibold text-slate-900">Custom evaluation</h3>
+              <p className="mt-2 text-sm text-slate-600">
+                Guide evolution with your own scripts and metrics.
+              </p>
+            </div>
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-2xl">📊</div>
+              <h3 className="mt-2 text-lg font-semibold text-slate-900">Interactive monitoring</h3>
+              <p className="mt-2 text-sm text-slate-600">
+                Visualize progress and compare variants in real time.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How It Works Section */}
+      <section className="px-4 py-16">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold text-slate-900">How it works</h2>
+          <div className="mt-8 grid gap-6 md:grid-cols-4">
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-lg font-semibold text-slate-900">1. Provide seed</div>
+              <p className="mt-2 text-sm text-slate-600">Upload an initial algorithm or start from scratch.</p>
+            </div>
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-lg font-semibold text-slate-900">2. Write evaluator</div>
+              <p className="mt-2 text-sm text-slate-600">Define the metrics that matter to you.</p>
+            </div>
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-lg font-semibold text-slate-900">3. Evolve automatically</div>
+              <p className="mt-2 text-sm text-slate-600">The system explores variants in parallel.</p>
+            </div>
+            <div className="rounded-xl bg-white p-6 text-center shadow-sm">
+              <div className="text-lg font-semibold text-slate-900">4. Review results</div>
+              <p className="mt-2 text-sm text-slate-600">Compare performance curves and choose the best.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Example Results Section */}
+      <section className="bg-slate-50 px-4 py-16">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold text-slate-900">Example evolution</h2>
+          <div className="mt-8 overflow-x-auto">
+            <table className="w-full text-left text-sm text-slate-600">
+              <thead className="bg-slate-100 text-slate-900">
+                <tr>
+                  <th className="p-3">Variant</th>
+                  <th className="p-3">Latency</th>
+                  <th className="p-3">Accuracy</th>
+                  <th className="p-3">Iterations</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b">
+                  <td className="p-3 font-medium text-slate-900">Baseline</td>
+                  <td className="p-3">120ms</td>
+                  <td className="p-3">92%</td>
+                  <td className="p-3">—</td>
+                </tr>
+                <tr className="border-b">
+                  <td className="p-3 font-medium text-slate-900">Variant A</td>
+                  <td className="p-3">98ms</td>
+                  <td className="p-3">93%</td>
+                  <td className="p-3">15</td>
+                </tr>
+                <tr>
+                  <td className="p-3 font-medium text-slate-900">Variant B</td>
+                  <td className="p-3">85ms</td>
+                  <td className="p-3">95%</td>
+                  <td className="p-3">30</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -1,9 +1,8 @@
 'use client';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import MonacoEditor from '@/components/MonacoEditor';
 import { useStarted } from '@/lib/state';
 import { startEvolution, getPromptDefaults } from '@/lib/api';
-import LineChart from '@/components/LineChart';
 import { useRouter } from 'next/navigation';
 
 const SAMPLE = `def bubble_sort(arr):
@@ -70,8 +69,14 @@ async function readFileAsText(file: File): Promise<string> {
 function chooseSeed(uploaded: string, editor: string) { return uploaded && uploaded.length > 0 ? uploaded : editor; }
 
 export default function ProjectHubPage(){
-  const { started, setStarted } = useStarted();
+  const { started } = useStarted();
   const router = useRouter();
+
+  useEffect(() => {
+    if (!started) {
+      router.replace('/');
+    }
+  }, [started, router]);
 
   const [code, setCode] = useState<string>(SAMPLE);
   const [seedCode, setSeedCode] = useState<string>('');
@@ -116,17 +121,6 @@ export default function ProjectHubPage(){
   ];
 
   const usedSeed = useMemo(()=> chooseSeed(seedCode, code), [seedCode, code]);
-  const hubRef = useRef<HTMLDivElement | null>(null);
-
-  const handleHeroStart = () => {
-    setStarted(true);
-  };
-
-  useEffect(() => {
-    if (started) {
-      hubRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, [started]);
 
   useEffect(() => {
     getPromptDefaults()
@@ -186,134 +180,16 @@ export default function ProjectHubPage(){
     }
   };
 
+  if (!started) return null;
+
   return (
     <div className="min-h-screen">
-      {/* Landing Hero */}
-      {!started && (
-        <>
-        <section id="project-hub-hero" className="relative overflow-hidden bg-white">
-          <div className="w-full min-h-screen px-4 py-14 md:py-20">
-            <div className="grid items-center gap-8 md:grid-cols-2">
-              <div>
-                <div className="inline-flex items-center gap-2 rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-xs font-medium text-violet-700">AlphaEvolve · Evolutionary Coding</div>
-                <h1 className="mt-4 text-3xl md:text-4xl font-bold tracking-tight text-slate-900">自动演化与评估，让代码自我进化</h1>
-                <p className="mt-3 text-slate-600">AlphaEvolve 将遗传算法与多指标评估结合，自动产生候选实现、并在多个岛屿并行演化。实时监控整体性能曲线，比较不同变体，快速找到更优解。</p>
-                <ul className="mt-5 list-inside list-disc space-y-2 text-sm text-slate-600">
-                  <li>支持自定义 <span className="font-medium">Seed Algorithm</span> 与 <span className="font-medium">Evaluator</span></li>
-                  <li>多指标优化（Latency/Accuracy/…）</li>
-                  <li>监控面板与结果工作台，便于对比与回溯</li>
-                </ul>
-                <div className="mt-6 flex items-center gap-3">
-                  <button
-                    data-testid="hero-start"
-                    onClick={handleHeroStart}
-                    className="rounded-xl bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-violet-700"
-                  >
-                    Start
-                  </button>
-                  <span className="text-sm text-slate-500">点击 Start 后将解锁页面功能</span>
-                </div>
-              </div>
-              <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                <div className="text-sm font-medium text-slate-900">演化过程概览</div>
-                <div className="mt-2 text-xs text-slate-500">示意图（Demo 数据）</div>
-                <div className="mt-3">
-                  <LineChart data={[0.1,0.12,0.2,0.18,0.28,0.33,0.38,0.42,0.5,0.58,0.63,0.71,0.76,0.8,0.83,0.86,0.9,0.93,0.95,0.98]} height={180}/>
-                </div>
-              </div>
-            </div>
+      <div id="hub" className="mx-auto max-w-6xl space-y-6 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">Project Hub</h2>
+            <p className="text-sm text-slate-500">Define problems and start evolution</p>
           </div>
-        </section>
-        <section className="bg-slate-50 px-4 py-16">
-          <div className="mx-auto max-w-5xl">
-            <h2 className="text-center text-2xl font-bold text-slate-900">特色与优势</h2>
-            <div className="mt-8 grid gap-6 md:grid-cols-3">
-              <div className="rounded-xl bg-white p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-slate-900">自动演化</h3>
-                <p className="mt-2 text-sm text-slate-600">根据评估指标自动生成和优化代码实现，不断提高性能。</p>
-              </div>
-              <div className="rounded-xl bg-white p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-slate-900">自定义评估</h3>
-                <p className="mt-2 text-sm text-slate-600">拥抱您自定义的评估脚本，以导向演化期望的目标。</p>
-              </div>
-              <div className="rounded-xl bg-white p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-slate-900">交互式监控</h3>
-                <p className="mt-2 text-sm text-slate-600">实时可视化评估数据，便于比较不同方案和追踪演化过程。</p>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section className="px-4 py-16">
-          <div className="mx-auto max-w-5xl">
-            <h2 className="text-center text-2xl font-bold text-slate-900">工作原理</h2>
-            <div className="mt-8 grid gap-6 md:grid-cols-4">
-              <div className="rounded-xl bg-white p-6 text-center shadow-sm">
-                <div className="text-lg font-semibold text-slate-900">1. 提供 Seed</div>
-                <p className="mt-2 text-sm text-slate-600">上传初始算法或直接在编辑器中编写。</p>
-              </div>
-              <div className="rounded-xl bg-white p-6 text-center shadow-sm">
-                <div className="text-lg font-semibold text-slate-900">2. 编写评估</div>
-                <p className="mt-2 text-sm text-slate-600">定义度量标准，引导演化方向。</p>
-              </div>
-              <div className="rounded-xl bg-white p-6 text-center shadow-sm">
-                <div className="text-lg font-semibold text-slate-900">3. 自动演化</div>
-                <p className="mt-2 text-sm text-slate-600">系统并行生成变体并运行评估。</p>
-              </div>
-              <div className="rounded-xl bg-white p-6 text-center shadow-sm">
-                <div className="text-lg font-semibold text-slate-900">4. 对比结果</div>
-                <p className="mt-2 text-sm text-slate-600">监控性能曲线，快速挑选更优解。</p>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section className="bg-slate-50 px-4 py-16">
-          <div className="mx-auto max-w-5xl">
-            <h2 className="text-center text-2xl font-bold text-slate-900">示例演化结果</h2>
-            <div className="mt-8 overflow-x-auto">
-              <table className="w-full text-left text-sm text-slate-600">
-                <thead className="bg-slate-100 text-slate-900">
-                  <tr>
-                    <th className="p-3">Variant</th>
-                    <th className="p-3">Latency</th>
-                    <th className="p-3">Accuracy</th>
-                    <th className="p-3">Iterations</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr className="border-b">
-                    <td className="p-3 font-medium text-slate-900">Baseline</td>
-                    <td className="p-3">120ms</td>
-                    <td className="p-3">92%</td>
-                    <td className="p-3">—</td>
-                  </tr>
-                  <tr className="border-b">
-                    <td className="p-3 font-medium text-slate-900">Variant A</td>
-                    <td className="p-3">98ms</td>
-                    <td className="p-3">93%</td>
-                    <td className="p-3">15</td>
-                  </tr>
-                  <tr>
-                    <td className="p-3 font-medium text-slate-900">Variant B</td>
-                    <td className="p-3">85ms</td>
-                    <td className="p-3">95%</td>
-                    <td className="p-3">30</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </section>
-        </>
-      )}
-
-      {/* Hub Editor Section — only visible after started */}
-      {started && (
-        <div id="hub" ref={hubRef} className="mx-auto max-w-6xl space-y-6 p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900">Project Hub</h2>
-              <p className="text-sm text-slate-500">Define problems and start evolution</p>
-            </div>
             <button
               data-testid="start-evolution"
               className="rounded-xl bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-violet-700 disabled:opacity-50"
@@ -530,7 +406,7 @@ export default function ProjectHubPage(){
             </div>
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/alpha_frontend/components/TopNav.tsx
+++ b/alpha_frontend/components/TopNav.tsx
@@ -15,7 +15,7 @@ export default function TopNav(){
   );
   return (
     <div className="sticky top-0 z-50 flex items-center justify-between border-b border-slate-200 bg-white/80 px-6 h-16 backdrop-blur shadow-sm">
-      <div className="font-semibold text-slate-900 text-xl">AlphaEvolve</div>
+      <Link href="/" className="font-semibold text-slate-900 text-xl">AlphaEvolve</Link>
       <div data-testid="nav-tabs" aria-hidden={!started} className="flex items-center gap-3">
         {started && <Item href="/project-hub" label="Project Hub"/>}
         {started && <Item href="/monitor" label="Monitor"/>}


### PR DESCRIPTION
## Summary
- add a dedicated landing page with hero, features, and start button
- streamline project hub to only show editor and redirect when not started
- link top nav logo back to home for easier navigation

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run test:e2e` *(fails: sh: 1: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92faa57b08328889c536b9459c274