### PR TITLE
Refine Project Hub UI layout

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -182,185 +182,183 @@ export default function ProjectHubPage(){
 
   if (!started) {
     return null;
-  }lstack-integration
+  }
 
   return (
-    <div className="min-h-screen">
+    <main className="min-h-screen bg-slate-50">
       <div id="hub" className="mx-auto max-w-6xl space-y-6 p-6">
-        <div className="flex items-center justify-between">
+        <header className="flex items-center justify-between">
           <div>
             <h2 className="text-xl font-semibold text-slate-900">Project Hub</h2>
             <p className="text-sm text-slate-500">Define problems and start evolution</p>
           </div>
-            <button
-              data-testid="start-evolution"
-              className="rounded-xl bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-violet-700 disabled:opacity-50"
-              onClick={handleStartEvolution}
-              disabled={isStarting}
-            >
-              {isStarting ? 'Starting...' : 'Start Evolution'}
-            </button>
-          </div>
+          <button
+            data-testid="start-evolution"
+            className="rounded-xl bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-violet-700 disabled:opacity-50"
+            onClick={handleStartEvolution}
+            disabled={isStarting}
+          >
+            {isStarting ? 'Starting...' : 'Start Evolution'}
+          </button>
+        </header>
 
-            <div className="space-y-6">
-              <div>
-                <div className="mb-2 flex items-center justify-between">
-                  <div className="text-sm font-medium text-slate-900">Seed Algorithm</div>
-                  <div className="flex items-center gap-2 text-xs text-slate-500">
-                    <label className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-slate-100">
-                      <span>Upload</span>
-                      <input
-                        data-testid="upload-seed"
-                        type="file"
-                        className="hidden"
-                        accept=".py,.txt"
-                        onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setSeedCode(await readFileAsText(f)); setSeedFileName(f.name); }}
-                      />
-                    </label>
-                    {seedFileName && (
-                      <button
-                        data-testid="clear-seed"
-                        className="rounded-md px-2 py-1 hover:bg-slate-100"
-                        onClick={()=>{ setSeedCode(''); setSeedFileName(''); }}
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                </div>
-                {seedFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {seedFileName}</div>}
-                <MonacoEditor value={usedSeed} onChange={seedCode?undefined:setCode} height={420}/>
-              </div>
-
-              <div className="flex justify-center">
-                <div className="w-full max-w-3xl rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                  <div className="mb-3 flex items-center justify-between">
-                    <div className="text-sm font-medium text-slate-900">Evaluator</div>
-                    {evalFileName && (
-                      <button
-                        data-testid="clear-evaluator"
-                        className="rounded-md px-2 py-1 hover:bg-slate-100"
-                        onClick={()=>{ setEvaluatorText(''); setEvalFileName(''); }}
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                  {evalFileName ? (
-                    <>
-                      <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {evalFileName}</div>
-                      <MonacoEditor value={evaluatorText} height={160} language="python" readOnly />
-                    </>
-                  ) : (
-                    <label className="flex h-60 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
-                      Upload an evaluator script (.py)
-                      <input data-testid="upload-evaluator" type="file" className="hidden" accept=".py" onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setEvaluatorText(await readFileAsText(f)); setEvalFileName(f.name); }} />
-                    </label>
-                  )}
-                </div>
-              </div>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-              <div className="mb-3 flex items-center justify-between">
-                <div className="text-sm font-medium text-slate-900">Run Configuration</div>
-                {cfgFileName && (
-                  <button
-                    data-testid="clear-config"
-                    className="rounded-md px-2 py-1 hover:bg-slate-100"
-                    onClick={()=>{ setCfgFile(null); setCfgFileName(''); setCfgText(''); }}
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-              {cfgFileName ? (
-                <>
-                  <div className="text-xs text-slate-500">Uploaded: {cfgFileName}</div>
-                  <MonacoEditor value={cfgText} height={180} language="yaml" readOnly />
-                </>
-              ) : (
-                <label className="mt-2 flex h-40 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
-
-                  Upload a config file (.yaml)
-                  <input
-                    data-testid="upload-config"
-                    type="file"
-                    className="hidden"
-                    accept=".yaml"
-                    onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setCfgFile(f); setCfgFileName(f.name); setCfgText(await readFileAsText(f)); }}
-                  />
-                </label>
-              )}
-              <details className="mt-3 text-xs text-slate-500">
-                <summary className="cursor-pointer">View example config</summary>
-            <pre className="mt-2 max-h-64 overflow-auto rounded-lg bg-slate-50 p-3 text-left font-mono leading-5 text-slate-700">{SAMPLE_CONFIG}</pre>
-              </details>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-              <div className="mb-3 flex items-center justify-between">
-                <div className="text-sm font-medium text-slate-900">Prompts</div>
+          <section className="space-y-6">
+            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="text-sm font-medium text-slate-900">Seed Algorithm</div>
                 <div className="flex items-center gap-2 text-xs text-slate-500">
                   <label className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-slate-100">
                     <span>Upload</span>
                     <input
-                      data-testid="upload-prompts"
+                      data-testid="upload-seed"
                       type="file"
                       className="hidden"
-                      accept=".json,.txt"
-                      onChange={async (e)=>{
-                        const f = e.target.files?.[0];
-                        if(!f) return;
-                        const text = await readFileAsText(f);
-                        try {
-                          const d = JSON.parse(text);
-                          setSystemPrompt(d.system_message || '');
-                          setDiffUserPrompt(d.diff_user || '');
-                          setFullRewritePrompt(d.full_rewrite_user || '');
-                          setEvaluationPrompt(d.evaluation || '');
-                        } catch {
-                          setPromptValue(text);
-                        }
-                        setPromptFileName(f.name);
-                      }}
+                      accept=".py,.txt"
+                      onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setSeedCode(await readFileAsText(f)); setSeedFileName(f.name); }}
                     />
                   </label>
-                  {promptFileName && (
+                  {seedFileName && (
                     <button
-                      data-testid="clear-prompts"
+                      data-testid="clear-seed"
                       className="rounded-md px-2 py-1 hover:bg-slate-100"
-                      onClick={()=>{
-                        setPromptFileName('');
-                        setSystemPrompt('');
-                        setDiffUserPrompt('');
-                        setFullRewritePrompt('');
-                        setEvaluationPrompt('');
-                      }}
+                      onClick={()=>{ setSeedCode(''); setSeedFileName(''); }}
                     >
                       Clear
                     </button>
                   )}
                 </div>
               </div>
-              {promptFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {promptFileName}</div>}
-              <div className="mb-3 flex flex-wrap gap-2">
-                {promptTabs.map((t) => (
+              {seedFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {seedFileName}</div>}
+              <MonacoEditor value={usedSeed} onChange={seedCode?undefined:setCode} height={420} />
+            </section>
+
+            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between">
+                <div className="text-sm font-medium text-slate-900">Evaluator</div>
+                {evalFileName && (
                   <button
-                    key={t.key}
-                    type="button"
-                    onClick={() => setActivePrompt(t.key)}
-                    className={`rounded-lg border px-3 py-1 text-xs font-medium ${
-                      activePrompt === t.key
-                        ? 'bg-violet-600 text-white border-violet-600'
-                        : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-100'
-                    }`}
+                    data-testid="clear-evaluator"
+                    className="rounded-md px-2 py-1 hover:bg-slate-100"
+                    onClick={()=>{ setEvaluatorText(''); setEvalFileName(''); }}
                   >
-                    {t.label}
+                    Clear
                   </button>
-                ))}
+                )}
               </div>
-              <MonacoEditor height={420} value={promptValue} onChange={setPromptValue} />
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              {evalFileName ? (
+                <>
+                  <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {evalFileName}</div>
+                  <MonacoEditor value={evaluatorText} height={160} language="python" readOnly />
+                </>
+              ) : (
+                <label className="flex h-60 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
+                  Upload an evaluator script (.py)
+                  <input data-testid="upload-evaluator" type="file" className="hidden" accept=".py" onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setEvaluatorText(await readFileAsText(f)); setEvalFileName(f.name); }} />
+                </label>
+              )}
+            </section>
+
+              <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="text-sm font-medium text-slate-900">Run Configuration</div>
+                  {cfgFileName && (
+                    <button
+                      data-testid="clear-config"
+                      className="rounded-md px-2 py-1 hover:bg-slate-100"
+                      onClick={()=>{ setCfgFile(null); setCfgFileName(''); setCfgText(''); }}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                {cfgFileName ? (
+                  <>
+                    <div className="text-xs text-slate-500">Uploaded: {cfgFileName}</div>
+                    <MonacoEditor value={cfgText} height={180} language="yaml" readOnly />
+                  </>
+                ) : (
+                  <label className="mt-2 flex h-40 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 transition-colors hover:border-violet-400 hover:bg-violet-50 hover:text-violet-600">
+
+                    Upload a config file (.yaml)
+                    <input
+                      data-testid="upload-config"
+                      type="file"
+                      className="hidden"
+                      accept=".yaml"
+                      onChange={async (e)=>{ const f = e.target.files?.[0]; if(!f) return; setCfgFile(f); setCfgFileName(f.name); setCfgText(await readFileAsText(f)); }}
+                    />
+                  </label>
+                )}
+                <details className="mt-3 text-xs text-slate-500">
+                  <summary className="cursor-pointer">View example config</summary>
+              <pre className="mt-2 max-h-64 overflow-auto rounded-lg bg-slate-50 p-3 text-left font-mono leading-5 text-slate-700">{SAMPLE_CONFIG}</pre>
+                </details>
+              </section>
+              <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="text-sm font-medium text-slate-900">Prompts</div>
+                  <div className="flex items-center gap-2 text-xs text-slate-500">
+                    <label className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-slate-100">
+                      <span>Upload</span>
+                      <input
+                        data-testid="upload-prompts"
+                        type="file"
+                        className="hidden"
+                        accept=".json,.txt"
+                        onChange={async (e)=>{
+                          const f = e.target.files?.[0];
+                          if(!f) return;
+                          const text = await readFileAsText(f);
+                          try {
+                            const d = JSON.parse(text);
+                            setSystemPrompt(d.system_message || '');
+                            setDiffUserPrompt(d.diff_user || '');
+                            setFullRewritePrompt(d.full_rewrite_user || '');
+                            setEvaluationPrompt(d.evaluation || '');
+                          } catch {
+                            setPromptValue(text);
+                          }
+                          setPromptFileName(f.name);
+                        }}
+                      />
+                    </label>
+                    {promptFileName && (
+                      <button
+                        data-testid="clear-prompts"
+                        className="rounded-md px-2 py-1 hover:bg-slate-100"
+                        onClick={()=>{
+                          setPromptFileName('');
+                          setSystemPrompt('');
+                          setDiffUserPrompt('');
+                          setFullRewritePrompt('');
+                          setEvaluationPrompt('');
+                        }}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {promptFileName && <div className="mb-2 truncate text-xs text-slate-500">Uploaded: {promptFileName}</div>}
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {promptTabs.map((t) => (
+                    <button
+                      key={t.key}
+                      type="button"
+                      onClick={() => setActivePrompt(t.key)}
+                      className={`rounded-lg border px-3 py-1 text-xs font-medium ${
+                        activePrompt === t.key
+                          ? 'bg-violet-600 text-white border-violet-600'
+                          : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-100'
+                      }`}
+                    >
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+                <MonacoEditor height={420} value={promptValue} onChange={setPromptValue} />
+              </section>
+              <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
               <div className="mb-3 flex items-center justify-between">
                 <div className="text-sm font-medium text-slate-900">Context</div>
                 {!showContext ? (
@@ -400,13 +398,12 @@ export default function ProjectHubPage(){
                     }}
                   />
                   <p className="mt-1 text-xs text-slate-500">Optional JSON context passed to evaluator</p>
-                  {contextError && <p className="mt-1 text-xs text-red-600">{contextError}</p>}
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+                {contextError && <p className="mt-1 text-xs text-red-600">{contextError}</p>}
+              </>
+            )}
+          </section>
+        </section>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace stray text and redundant wrappers on Project Hub page
- reorganize page using semantic `main`, `header`, and `section` elements for clearer layout
- consolidate seed, evaluator, configuration, prompts, and context into card-style sections

## Testing
- `pytest`
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run test:e2e` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68ba462764c483288cbd1baf0280da9e