### PR TITLE
Adjust navigation to monitor and internal visualization

### DIFF
--- a/alpha_frontend/app/monitor/page.tsx
+++ b/alpha_frontend/app/monitor/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import LineChart from '@/components/LineChart';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-const VISUALIZER_BASE = process.env.NEXT_PUBLIC_VISUALIZER_BASE || 'http://localhost:8080';
 
 interface ProgramSummary {
   id: string;
@@ -30,6 +30,7 @@ export default function MonitorPage() {
   const [outputPath, setOutputPath] = useState<string | null>(null);
   const [status, setStatus] = useState<string>('idle');
   const [data, setData] = useState<MonitorResponse | null>(null);
+  const router = useRouter();
 
   // Get runId and outputPath from localStorage or URL
   useEffect(() => {
@@ -135,14 +136,14 @@ export default function MonitorPage() {
         <div className="flex items-center gap-2">
           {runId && outputPath && (
             <>
-              <a
-                href={`${VISUALIZER_BASE}/?path=${encodeURIComponent(outputPath)}`}
-                target="_blank"
-                rel="noopener noreferrer"
+              <button
+                onClick={() =>
+                  router.push(`/visualize?runId=${runId}&path=${encodeURIComponent(outputPath)}`)
+                }
                 className="rounded-xl bg-green-600 px-3 py-2 text-sm font-medium text-white shadow hover:bg-green-700"
               >
                 Visualize
-              </a>
+              </button>
               <button
                 onClick={handleStop}
                 className="rounded-xl bg-red-600 px-3 py-2 text-sm font-medium text-white shadow hover:bg-red-700"

--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -168,9 +168,9 @@ export default function ProjectHubPage(){
         if (result.path) {
           localStorage.setItem('currentOutputPath', result.path);
         }
-        // Navigate directly to visualization page with runId and path
+        // Navigate to monitoring page with runId and path
         const pathParam = result.path ? `&path=${encodeURIComponent(result.path)}` : '';
-        router.push(`/visualize?runId=${result.runId}${pathParam}`);
+        router.push(`/monitor?runId=${result.runId}${pathParam}`);
       }
     } catch (error) {
       console.error('Failed to start evolution:', error);

--- a/alpha_frontend/app/visualize/page.tsx
+++ b/alpha_frontend/app/visualize/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 const VISUALIZER_BASE = process.env.NEXT_PUBLIC_VISUALIZER_BASE || 'http://localhost:8080';
@@ -7,6 +8,7 @@ const VISUALIZER_BASE = process.env.NEXT_PUBLIC_VISUALIZER_BASE || 'http://local
 export default function VisualizePage() {
   const [runId, setRunId] = useState<string | null>(null);
   const [outputPath, setOutputPath] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const storedRunId = localStorage.getItem('currentRunId');
@@ -56,7 +58,13 @@ export default function VisualizePage() {
 
   return (
     <div className="p-4 space-y-4">
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between">
+        <button
+          onClick={() => router.push('/monitor')}
+          className="rounded-xl bg-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-300"
+        >
+          Back to Monitor
+        </button>
         {runId && (
           <button
             onClick={handleStop}


### PR DESCRIPTION
## Summary
- Redirect start workflow to monitor dashboard
- Visualize results within Next.js app instead of external 8080 link

## Testing
- `python -m unittest discover tests` *(fails: AttributeError: 'NoneType' object has no attribute 'request_shutdown')*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7f860ff08328ad5a7c5c66eeae48