### PR TITLE
feat(frontend): add use default config option

### DIFF
--- a/alpha_frontend/app/project-hub/page.tsx
+++ b/alpha_frontend/app/project-hub/page.tsx
@@ -261,19 +261,28 @@ export default function ProjectHubPage(){
               <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="mb-3 flex items-center justify-between">
                   <div className="text-sm font-medium text-slate-900">Run Configuration</div>
-                  {cfgFileName && (
+                  <div className="flex items-center gap-2 text-xs text-slate-500">
                     <button
-                      data-testid="clear-config"
+                      type="button"
                       className="rounded-md px-2 py-1 hover:bg-slate-100"
-                      onClick={()=>{ setCfgFile(null); setCfgFileName(''); setCfgText(''); }}
+                      onClick={()=>{ const f = new File([SAMPLE_CONFIG], 'default_config.yaml', { type: 'application/x-yaml' }); setCfgFile(f); setCfgFileName('default_config.yaml'); setCfgText(SAMPLE_CONFIG); }}
                     >
-                      Clear
+                      Use Default
                     </button>
-                  )}
+                    {cfgFileName && (
+                      <button
+                        data-testid="clear-config"
+                        className="rounded-md px-2 py-1 hover:bg-slate-100"
+                        onClick={()=>{ setCfgFile(null); setCfgFileName(''); setCfgText(''); }}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
                 </div>
                 {cfgFileName ? (
                   <>
-                    <div className="text-xs text-slate-500">Uploaded: {cfgFileName}</div>
+                    <div className="text-xs text-slate-500">Using: {cfgFileName}</div>
                     <MonacoEditor value={cfgText} height={180} language="yaml" readOnly />
                   </>
                 ) : (


### PR DESCRIPTION
## Summary
- add "Use Default" button in Project Hub run configuration to quickly load default_config.yaml
- display active configuration name in the Run Configuration panel

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run test:e2e` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68c0dfa091888328a28e2202b5a6a7f1