### PR TITLE
feat: show loading indicator on monitor start

### DIFF
--- a/alpha_frontend/app/monitor/page.tsx
+++ b/alpha_frontend/app/monitor/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import LineChart from '@/components/LineChart';
 import Sparkline from '@/components/Sparkline';
 import CodeBlock from '@/components/CodeBlock';
+import LoadingIndicator from '@/components/LoadingIndicator';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 
@@ -162,6 +163,15 @@ export default function MonitorPage() {
           )}
         </div>
       </div>
+
+      {runId && status === 'running' && (!data || data.history.length === 0) && (
+        <div className="flex flex-col items-center justify-center py-10">
+          <LoadingIndicator />
+          <p className="mt-4 text-sm text-slate-500">
+            Evolution started, waiting for data...
+          </p>
+        </div>
+      )}
 
       {runId && data && data.history.length > 0 && (
         <div className="rounded-2xl border border-slate-200 bg-white p-4">

--- a/alpha_frontend/components/LoadingIndicator.tsx
+++ b/alpha_frontend/components/LoadingIndicator.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export default function LoadingIndicator() {
+  return (
+    <svg
+      className="h-8 w-8 animate-spin text-violet-600"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add LoadingIndicator component
- show spinner on Monitor page while evolution is running before data arrives

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c0e4282ac08328ab54a3b5b2accc6e